### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+
+
+## License
+
+This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/sphinx-invoke/blob/master/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,0 @@
-
-
-## License
-
-This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/sphinx-invoke/blob/master/LICENSE).

--- a/README.rst
+++ b/README.rst
@@ -49,4 +49,4 @@ practices defined in crl-devutils_.
 License
 -------
 
-This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/sphinx-invoke/blob/master/LICENSE).
+This project is licensed under the BSD-3-Clause license - see the `LICENSE <https://github.com/nokia/sphinx-invoke/blob/master/LICENSE>`_.

--- a/README.rst
+++ b/README.rst
@@ -44,3 +44,9 @@ The development and the testing follows the Common Robot Libraries development
 practices defined in crl-devutils_.
 
 .. _crl-devutils: http://crl-devutils.readthedocs.io/.
+
+
+License
+-------
+
+This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/sphinx-invoke/blob/master/LICENSE).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.